### PR TITLE
Migrate from Travis to GitHub Actions

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -3,7 +3,7 @@
 
 name: Publish Node.js Package
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 15
+          node-version: 18
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm publish

--- a/.github/workflows/npm_test.yml
+++ b/.github/workflows/npm_test.yml
@@ -1,0 +1,36 @@
+# This workflow will run tests using node.
+name: Run NodeJS Tests
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+  # Run on every push.
+  push:
+
+  # Run on every pull request.
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [ 10, 12, 14, 16, 18, 20 ]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+
+      # Clean install of all dependencies.
+      - run: npm ci
+
+      # Run the tests
+      - run: npm test
+
+      # Generate coverage.
+      # Note: Commented out until vsiakka can configure this.
+      #- run: npm run coverage

--- a/.github/workflows/npm_test.yml
+++ b/.github/workflows/npm_test.yml
@@ -18,7 +18,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [ 10, 12, 14, 16, 18, 20 ]
+        # Note: Node 20.8 introduces a change which breaks mock-fs.
+        # https://github.com/tschaub/mock-fs/issues/380
+        node: [ 10, 12, 14, 16, 18, 20.7 ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -31,6 +33,18 @@ jobs:
       # Run the tests
       - run: npm test
 
-      # Generate coverage.
-      # Note: Commented out until vsiakka can configure this.
-      #- run: npm run coverage
+      - name: Coveralls Parallel
+        uses: coverallsapp/github-action@v2
+        with:
+          flag-name: run-${{ join(matrix.*, '-') }}
+          parallel: true
+
+  finish:
+    needs: test
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@v2
+      with:
+        parallel-finished: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-node_js:
-  - "node"
-  - "10"
-  - "12"
-  - "14"
-script: "npm test"
-after_success: npm run coverage

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Gherkin lint
-[![Travis](https://travis-ci.com/vsiakka/gherkin-lint.svg?branch=master)](https://travis-ci.com/github/vsiakka/gherkin-lint/branches)
-[![Coverage Status](https://coveralls.io/repos/github/vsiakka/gherkin-lint/badge.svg?branch=master)](https://coveralls.io/github/vsiakka/gherkin-lint?branch=master)
-[![David](https://img.shields.io/david/vsiakka/gherkin-lint.svg?maxAge=2592000)](https://david-dm.org/vsiakka/gherkin-lint)
-[![David](https://img.shields.io/david/dev/vsiakka/gherkin-lint.svg?maxAge=2592000)](https://david-dm.org/vsiakka/gherkin-lint#info=devDependencies&view=table)
+[![Run NodeJS Tests](https://github.com/gherkin-lint/gherkin-lint/actions/workflows/npm_test.yml/badge.svg)](https://github.com/gherkin-lint/gherkin-lint/actions/workflows/npm_test.yml)
+[![Coverage Status](https://coveralls.io/repos/github/gherkin-lint/gherkin-lint/badge.svg?branch=master)](https://coveralls.io/github/gherkin-lint/gherkin-lint?branch=master)
 [![npm](https://img.shields.io/npm/v/gherkin-lint.svg?maxAge=2592000)](https://www.npmjs.com/package/gherkin-lint)
 
 Uses [Gherkin](https://github.com/cucumber/gherkin-javascript) to parse feature files and runs linting against the default rules, and the optional rules you specified in your `.gherkin-lintrc` file.
@@ -15,7 +13,7 @@ npm install gherkin-lint
 ## Demo
 To see the output for all the errors that the linter can detect run:
 ```
-git clone https://github.com/vsiakka/gherkin-lint.git
+git clone https://github.com/gherkin-lint/gherkin-lint.git
 npm run demo
 ```
 Or check this:

--- a/package.json
+++ b/package.json
@@ -132,12 +132,11 @@
   },
   "scripts": {
     "build": "babel src -d dist",
-    "coverage": "nyc report --reporter=text-lcov | coveralls",
     "demo": "node ./dist/main.js -c ./test-data-wip/.gherkin-lintrc test-data-wip/**",
     "lint": "eslint ./src ./test",
     "mocha": "mocha --recursive",
     "prepare": "npm run build",
-    "test": "npm run lint && npm run build && nyc -include=dist/** npm run mocha"
+    "test": "npm run lint && npm run build && nyc --reporter=lcovonly --reporter=html --reporter=text -include=dist/** npm run mocha"
   },
   "license": "ISC"
 }


### PR DESCRIPTION
This commit:
- removes the travis configuration
- adds a GHA for testing
- fixes the existing npm_publish to use the current LTS version of Node rather than the development version from v16

For the new GHA I have set the build versions to every release version of Node from 10 to 20.
I have also updated the publish action to use Node 18 (current LTS) instead of 15 (development version).